### PR TITLE
Fix trailing comma in package.json scripts

### DIFF
--- a/ClanTrust/package.json
+++ b/ClanTrust/package.json
@@ -7,7 +7,7 @@
     "lint": "next lint",
     "postinstall": "prisma generate",
     "db:migrate": "prisma migrate dev --name init",
-    "db:deploy": "prisma migrate deploy",
+    "db:deploy": "prisma migrate deploy"
   },
   "dependencies": {
     "@clerk/nextjs": "^4.29.5",


### PR DESCRIPTION
## Summary
- remove the trailing comma from the db:deploy script to restore valid JSON in package.json

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e199a412a883329eb9084b8bfcbfbe