### PR TITLE
Add missing inverse relation for data export requests

### DIFF
--- a/ClanTrust/package.json
+++ b/ClanTrust/package.json
@@ -7,7 +7,7 @@
     "lint": "next lint",
     "postinstall": "prisma generate",
     "db:migrate": "prisma migrate dev --name init",
-    "db:deploy": "prisma migrate deploy",
+    "db:deploy": "prisma migrate deploy"
   },
   "dependencies": {
     "@clerk/nextjs": "^4.29.5",

--- a/ClanTrust/prisma/schema.prisma
+++ b/ClanTrust/prisma/schema.prisma
@@ -30,6 +30,7 @@ model User {
   profile   Profile?
   documents Document[] @relation("DocumentOwner")
   consents  Consent[]
+  dataExportRequests DataExportRequest[]
 }
 
 model Profile {


### PR DESCRIPTION
## Summary
- add the missing DataExportRequest relation to the User model so Prisma can wire the association in both directions

## Testing
- npx prisma format *(fails: blocked from downloading Prisma engine checksums in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e199a412a883329eb9084b8bfcbfbe